### PR TITLE
add an adapter API for binding adapters for major ActiveRecord versions

### DIFF
--- a/lib/assert-activerecord.rb
+++ b/lib/assert-activerecord.rb
@@ -1,4 +1,48 @@
 require "assert-activerecord/version"
+require "assert-activerecord/adapter"
 
 module AssertActiveRecord
+
+  def self.adapter(instance = nil)
+    @adapter = instance if !instance.nil?
+    @adapter
+  end
+
+  def self.reset_db
+    @reset_db ||= begin
+      self.reset_db!
+      true
+    end
+  end
+
+  def self.reset_db!
+    self.drop_db
+    self.create_db
+    self.load_schema
+    self.connect_db
+  end
+
+  def self.drop_db
+    self.adapter.drop_db
+  end
+
+  def self.create_db
+    self.adapter.create_db
+  end
+
+  def self.load_schema
+    self.adapter.load_schema
+  end
+
+  def self.connect_db
+    self.adapter.connect_db
+  end
+
+  class DefaultAdapter
+    include AssertActiveRecord::Adapter
+
+  end
+
+  self.adapter(DefaultAdapter.new)
+
 end

--- a/lib/assert-activerecord/adapter.rb
+++ b/lib/assert-activerecord/adapter.rb
@@ -1,0 +1,27 @@
+module AssertActiveRecord
+
+  module Adapter
+
+    def test_env_name
+      "test"
+    end
+
+    def drop_db
+      raise NotImplementedError
+    end
+
+    def create_db
+      raise NotImplementedError
+    end
+
+    def load_schema
+      raise NotImplementedError
+    end
+
+    def connect_db
+      raise NotImplementedError
+    end
+
+  end
+
+end

--- a/test/unit/adapter_tests.rb
+++ b/test/unit/adapter_tests.rb
@@ -1,0 +1,50 @@
+require "assert"
+require "assert-activerecord/adapter"
+
+module AssertActiveRecord::Adapter
+
+  class UnitTests < Assert::Context
+    desc "AssertActiveRecord::Adapter"
+    setup do
+      @module = AssertActiveRecord::Adapter
+    end
+    subject{ @module }
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      adapter_class = Class.new do
+        include AssertActiveRecord::Adapter
+      end
+      @adapter = adapter_class.new
+    end
+    subject{ @adapter }
+
+    should have_imeths :test_env_name
+    should have_imeths :drop_db, :create_db, :load_schema, :connect_db
+
+    should "know its test env name" do
+      assert_equal "test", subject.test_env_name
+    end
+
+    should "not implement its drop db method" do
+      assert_raises(NotImplementedError){ subject.drop_db }
+    end
+
+    should "not implement its create db method" do
+      assert_raises(NotImplementedError){ subject.create_db }
+    end
+
+    should "not implement its load schema method" do
+      assert_raises(NotImplementedError){ subject.load_schema }
+    end
+
+    should "not implement its connect db method" do
+      assert_raises(NotImplementedError){ subject.connect_db }
+    end
+
+  end
+
+end

--- a/test/unit/assert-activerecord_tests.rb
+++ b/test/unit/assert-activerecord_tests.rb
@@ -1,0 +1,110 @@
+require "assert"
+require "assert-activerecord"
+
+module AssertActiveRecord
+
+  class UnitTests < Assert::Context
+    desc "AssertActiveRecord"
+    setup do
+      @module = AssertActiveRecord
+    end
+    subject{ @module }
+
+    should have_imeths :adapter
+    should have_imeths :reset_db, :reset_db!
+    should have_imeths :drop_db, :create_db, :load_schema, :connect_db
+
+    should "set the DefaultAdapter as its adapter by default" do
+      assert_instance_of DefaultAdapter, AssertActiveRecord.adapter
+    end
+
+    should "call to the adapter for its adapter methods" do
+      assert_raises(NotImplementedError){ subject.drop_db }
+      assert_raises(NotImplementedError){ subject.create_db }
+      assert_raises(NotImplementedError){ subject.load_schema }
+      assert_raises(NotImplementedError){ subject.connect_db }
+    end
+
+  end
+
+  class ResetDbTests < UnitTests
+    desc "when resetting the db"
+    setup do
+      @adapter_spy = AdapterSpy.new
+      Assert.stub(AssertActiveRecord, :adapter){ @adapter_spy }
+    end
+
+    should "run adapter cmds to reset the db only once" do
+      assert_equal [], @adapter_spy.cmds_called
+
+      subject.reset_db
+
+      exp = ["drop_db", "create_db", "load_schema", "connect_db"]
+      assert_equal exp, @adapter_spy.cmds_called
+
+      subject.reset_db
+
+      exp = ["drop_db", "create_db", "load_schema", "connect_db"]
+      assert_equal exp, @adapter_spy.cmds_called
+    end
+
+    should "force re-run adapter cmds to reset the db" do
+      assert_equal [], @adapter_spy.cmds_called
+
+      subject.reset_db!
+
+      exp = ["drop_db", "create_db", "load_schema", "connect_db"]
+      assert_equal exp, @adapter_spy.cmds_called
+
+      subject.reset_db!
+
+      exp = [
+        "drop_db", "create_db", "load_schema", "connect_db",
+        "drop_db", "create_db", "load_schema", "connect_db"
+      ]
+      assert_equal exp, @adapter_spy.cmds_called
+    end
+
+  end
+
+  class DefaultAdapterTests < UnitTests
+    desc "DefaultAdapter"
+    setup do
+      @class = DefaultAdapter
+    end
+    subject{ @class }
+
+    should "mixin AssertActiveRecord::Adapter" do
+      assert_includes AssertActiveRecord::Adapter, subject
+    end
+
+  end
+
+  class AdapterSpy
+    include AssertActiveRecord::Adapter
+
+    attr_reader :cmds_called
+
+    def initialize
+      @cmds_called = []
+    end
+
+    def drop_db
+      self.cmds_called << "drop_db"
+    end
+
+    def create_db
+      self.cmds_called << "create_db"
+    end
+
+    def load_schema
+      self.cmds_called << "load_schema"
+    end
+
+    def connect_db
+      self.cmds_called << "connect_db"
+    end
+
+  end
+
+end


### PR DESCRIPTION
This allows us to roll adapter gems for each major version of
ActiveRecord but still keep a common set of framework code in
this gem.

This also defines the adapter API methods for resetting test dbs
in test suites.

Usage:

In `Gemfile`:
```ruby
gem "assert-activerecord5"
```

In `test/helper.rb`:
```ruby
require "assert-activerecord5"
AssertActiveRecord.reset_db
```

@jcredding ready for review.