### PR TITLE
add Assert context for running database tests in a transaction

### DIFF
--- a/assert-activerecord.gemspec
+++ b/assert-activerecord.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '> 1.8'
 
-  gem.add_development_dependency("assert", ["~> 2.17.0"])
+  gem.add_dependency("assert", ["~> 2.17.0"])
 
 end

--- a/lib/assert-activerecord.rb
+++ b/lib/assert-activerecord.rb
@@ -1,5 +1,6 @@
 require "assert-activerecord/version"
 require "assert-activerecord/adapter"
+require "assert-activerecord/db_tests"
 
 module AssertActiveRecord
 
@@ -36,6 +37,14 @@ module AssertActiveRecord
 
   def self.connect_db
     self.adapter.connect_db
+  end
+
+  def self.transaction(&block)
+    self.adapter.transaction(&block)
+  end
+
+  def self.rollback!
+    self.adapter.rollback!
   end
 
   class DefaultAdapter

--- a/lib/assert-activerecord/adapter.rb
+++ b/lib/assert-activerecord/adapter.rb
@@ -22,6 +22,14 @@ module AssertActiveRecord
       raise NotImplementedError
     end
 
+    def transaction(&block)
+      raise NotImplementedError
+    end
+
+    def rollback!
+      raise NotImplementedError
+    end
+
   end
 
 end

--- a/lib/assert-activerecord/db_tests.rb
+++ b/lib/assert-activerecord/db_tests.rb
@@ -1,0 +1,15 @@
+require "assert"
+require "assert-activerecord"
+
+module AssertActiveRecord
+
+  class DbTests < Assert::Context
+    around do |block|
+      AssertActiveRecord.transaction do
+        block.call
+        AssertActiveRecord.rollback!
+      end
+    end
+  end
+
+end

--- a/test/unit/adapter_tests.rb
+++ b/test/unit/adapter_tests.rb
@@ -24,25 +24,19 @@ module AssertActiveRecord::Adapter
 
     should have_imeths :test_env_name
     should have_imeths :drop_db, :create_db, :load_schema, :connect_db
+    should have_imeths :transaction, :rollback!
 
     should "know its test env name" do
       assert_equal "test", subject.test_env_name
     end
 
-    should "not implement its drop db method" do
+    should "not implement its adapter methods" do
       assert_raises(NotImplementedError){ subject.drop_db }
-    end
-
-    should "not implement its create db method" do
       assert_raises(NotImplementedError){ subject.create_db }
-    end
-
-    should "not implement its load schema method" do
       assert_raises(NotImplementedError){ subject.load_schema }
-    end
-
-    should "not implement its connect db method" do
       assert_raises(NotImplementedError){ subject.connect_db }
+      assert_raises(NotImplementedError){ subject.transaction }
+      assert_raises(NotImplementedError){ subject.rollback! }
     end
 
   end

--- a/test/unit/assert-activerecord_tests.rb
+++ b/test/unit/assert-activerecord_tests.rb
@@ -13,6 +13,7 @@ module AssertActiveRecord
     should have_imeths :adapter
     should have_imeths :reset_db, :reset_db!
     should have_imeths :drop_db, :create_db, :load_schema, :connect_db
+    should have_imeths :transaction, :rollback!
 
     should "set the DefaultAdapter as its adapter by default" do
       assert_instance_of DefaultAdapter, AssertActiveRecord.adapter
@@ -23,6 +24,8 @@ module AssertActiveRecord
       assert_raises(NotImplementedError){ subject.create_db }
       assert_raises(NotImplementedError){ subject.load_schema }
       assert_raises(NotImplementedError){ subject.connect_db }
+      assert_raises(NotImplementedError){ subject.transaction }
+      assert_raises(NotImplementedError){ subject.rollback! }
     end
 
   end

--- a/test/unit/db_tests_tests.rb
+++ b/test/unit/db_tests_tests.rb
@@ -1,0 +1,42 @@
+require "assert"
+require "assert-activerecord/db_tests"
+
+class AssertActiveRecord::DbTests
+
+  class UnitTests < Assert::Context
+    desc "AssertActiveRecord::DbTests"
+    setup do
+      @transaction_called = false
+      Assert.stub(AssertActiveRecord, :transaction) do |&block|
+        @transaction_called = true
+        block.call
+      end
+
+      @rollback_called = false
+      Assert.stub(AssertActiveRecord, :rollback!) do
+        @rollback_called = true
+      end
+
+      @class = AssertActiveRecord::DbTests
+    end
+    subject{ @class }
+
+    should "be an Assert context" do
+      assert subject < Assert::Context
+    end
+
+    should "add an around callback to run tests in a rollback transaction" do
+      assert_equal 1, subject.arounds.size
+      callback = subject.arounds.first
+
+      block_yielded_to = false
+      callback.call(proc{ block_yielded_to = true })
+
+      assert_true @transaction_called
+      assert_true @rollback_called
+      assert_true block_yielded_to
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds a `DbTests` Assert context that has an `around` block
for running tests in a transaction and rolling them back after the
tests have run.

This allows not only speeds up your tests b/c you are not actually
persisting any data, it also allows you to do parallel test runs
b/c the database interactions are now multi-process safe because
of the transactions.

All of the ActiveRecord interactions are behind the adapter so
this just tests the adapter API.  In this case, I doubt the
ActiveRecord interactions will change over major versions (ie the
`transaction` and `rollback` apis are pretty stable), a design
principal is this gem cannot directly require ActiveRecord.
Therefore, all interactions must be behind the adapters.

@jcredding ready for review.